### PR TITLE
Add logging and verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ python -m umap create --coords "40.66,29.28" --radius 4000 --style vintage --dpi
 ```bash
 python -m umap create --help  # See all options for single map
 python -m umap batch --help   # See all options for batch processing
+# Increase verbosity with -v or -vv
+python -m umap create --coords "40.66,29.28" -v
 ```
 
 ## 📚 Python API Example


### PR DESCRIPTION
## Summary
- replace print statements in `umap/cli.py` with logging
- add a `--verbose`/`-v` flag to control log level
- mention the new option in the README

## Testing
- `python -m py_compile umap/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_684072b55c7c832390fa738dbacb3861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `-v/--verbose` flag to the CLI, allowing users to control the level of output detail.
- **Documentation**
  - Updated the README with examples and explanations for using the new verbosity flags in CLI commands.
- **Style**
  - User-facing messages are now displayed with improved formatting and appropriate severity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->