### PR TITLE
Add output format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ python umap "Los Angeles"
 umap --coords "40.66,29.28"
 
 # Custom options
-umap Istanbul --style vintage --radius 10000
+umap Istanbul --style vintage --radius 10000 --format pdf
 ```
 
 ![Yalova CLI Blueprint](yalova_cli_test.png)
@@ -63,9 +63,9 @@ umap Istanbul --style vintage --radius 10000
 
 ```bash
 umap --help              # See all options
-umap Istanbul --style blueprint --radius 8000
-umap "New York" --output "/path/to/my/map.png"
-umap --coords "40.66,29.28" --style vintage
+umap Istanbul --style blueprint --radius 8000 --format svg
+umap "New York" --output "/path/to/my/map.jpg" --format jpg
+umap --coords "40.66,29.28" --style vintage --format png
 ```
 
 **All maps are automatically saved to your Desktop unless you specify `--output`**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,6 +2,11 @@
 
 ## English
 
+### CLI Example
+```bash
+umap Istanbul --style vintage --format svg
+```
+
 ### Basic Usage
 ```python
 import umap
@@ -63,6 +68,11 @@ When no style is provided, Umap uses a minimalist black and white style:
 - Simple layer set (perimeter, streets, building)
 
 ## Türkçe
+
+### CLI Örneği
+```bash
+umap Istanbul --style vintage --format svg
+```
 
 ### Temel Kullanım
 ```python

--- a/umap/cli.py
+++ b/umap/cli.py
@@ -209,6 +209,9 @@ def get_desktop_path():
 def create_simple_map(args):
     """Create a single map with simplified arguments."""
     config = load_config(args.config)
+
+    # Determine output format
+    output_format = args.format or config['default']['format']
     
     # Parse location - handle both location name and coordinates
     if args.coords:
@@ -250,17 +253,20 @@ def create_simple_map(args):
             # Determine output path - default to Desktop
             if args.output:
                 output_path = args.output
+                if not os.path.splitext(output_path)[1]:
+                    output_path = f"{output_path}.{output_format}"
             else:
                 desktop_path = get_desktop_path()
-                output_filename = f"{location_name}_map.{config['default']['format']}"
+                output_filename = f"{location_name}_map.{output_format}"
                 output_path = os.path.join(desktop_path, output_filename)
-            
+
             map_plot.fig.savefig(
                 output_path,
                 dpi=dpi,
                 bbox_inches='tight',
                 facecolor='#fff',
-                pad_inches=0.5
+                pad_inches=0.5,
+                format=output_format
             )
             
             end_time = time.time()
@@ -308,6 +314,11 @@ def main():
     parser.add_argument(
         '--output',
         help='Output file path (default: Desktop/[location_name]_map.png)'
+    )
+    parser.add_argument(
+        '--format',
+        choices=['png', 'jpg', 'svg', 'pdf'],
+        help='Çıktı formatı'
     )
     parser.add_argument(
         '--dpi',


### PR DESCRIPTION
## Summary
- add `--format` CLI option to choose png, jpg, svg, or pdf
- honor chosen format when naming and saving maps
- document format usage in README and docs/usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b192f5f4e483239dfc0946ed2ee323